### PR TITLE
Fix for caves

### DIFF
--- a/src/com/wurmonline/wurmapi/api/MapData.java
+++ b/src/com/wurmonline/wurmapi/api/MapData.java
@@ -379,7 +379,7 @@ public final class MapData {
             throw new IllegalArgumentException("Tile type is invalid cave type: "+tileType.toString());
         }
         
-        setCaveTile(x, y, tileType, (short) 0, (byte) 0);
+        setCaveTile(x, y, tileType, (short) -100, (byte) 0);
     }
     
     private void setCaveTile(int x, int y, Tile tileType, short height, byte data) {


### PR DESCRIPTION
Set the default height of unopened caves.

Before it wouldn't let you open a tunnel. Checked decompiled server source as the server will generate a map_cave.map if it's not there, and found that it sets all cave tiles to a default height of -100.
