### PR TITLE
Cave fix

### DIFF
--- a/src/com/wurmonline/wurmapi/api/MapData.java
+++ b/src/com/wurmonline/wurmapi/api/MapData.java
@@ -404,7 +404,7 @@ public final class MapData {
         }
         
         setCaveResourceCount(x, y, resourceCount);
-        setCaveTile(x, y, tileType, (short) 0, (byte) 0);
+        setCaveTile(x, y, tileType, (short) -100, (byte) 0);
     }
     
     private void setCaveTile(int x, int y, Tile tileType, short height, byte data) {


### PR DESCRIPTION
Server sets cave tiles to -100 when it generates a new map, otherwise it thinks there's either a cave or opening and won't let you tunnel.

Tested with WGenerator.
