### PR TITLE
Dedicated Colorist interface for specifying tile colors

### DIFF
--- a/src/com/wurmonline/wurmapi/api/map/dump/Colorist.java
+++ b/src/com/wurmonline/wurmapi/api/map/dump/Colorist.java
@@ -1,65 +1,33 @@
 package com.wurmonline.wurmapi.api.map.dump;
 
 import com.wurmonline.mesh.GrassData;
-import com.wurmonline.mesh.Tiles;
 import com.wurmonline.mesh.Tiles.Tile;
-import com.wurmonline.wurmapi.internal.CaveColors;
 
 import java.awt.*;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
 
 /**
- * Provides colour information for map dumps
+ * Provides colour information for map dumps.
  */
-public class Colorist {
-    private static final Color PURPLE = Color.getHSBColor(0.7638888888888889f, 0.7f, 0.6f);
+public interface Colorist {
+    Color getFlowerColorFor(GrassData.FlowerType flowerType);
 
-    private static final Color YELLOW_GREEN = Color.getHSBColor(0.188888f, 1.0f, 0.9f);
+    Color getFlowerColorFor(int meshEncodedTile);
 
-    private static final Map<GrassData.FlowerType, Color> FLOWER_COLOUR;
-    static {
-        Map<GrassData.FlowerType, Color> flowerColour = new HashMap<>();
-        flowerColour.put(GrassData.FlowerType.FLOWER_1, Color.YELLOW);
-        flowerColour.put(GrassData.FlowerType.FLOWER_2, Color.ORANGE);
-        flowerColour.put(GrassData.FlowerType.FLOWER_3, PURPLE);
-        flowerColour.put(GrassData.FlowerType.FLOWER_4, Color.WHITE);
-        flowerColour.put(GrassData.FlowerType.FLOWER_5, Color.BLUE);
-        flowerColour.put(GrassData.FlowerType.FLOWER_6, YELLOW_GREEN);
-        flowerColour.put(GrassData.FlowerType.FLOWER_7, Color.PINK);
-        flowerColour.put(GrassData.FlowerType.NONE, Tile.TILE_GRASS.getColor());
-        FLOWER_COLOUR = Collections.unmodifiableMap(flowerColour);
-    }
+    Color getTreeColorFor(int meshEncodedTile);
 
-    public Color getFlowerColor(GrassData.FlowerType flowerType) {
-        return FLOWER_COLOUR.containsKey(flowerType) ?
-                FLOWER_COLOUR.get(flowerType) :
-                FLOWER_COLOUR.get(GrassData.FlowerType.NONE);
-    }
+    Color getSurfaceColorFor(Tile tile);
 
-    public Color getFlowerColor(int meshEncodedTile) {
-        byte grassData = Tiles.decodeData(meshEncodedTile);
-        return getFlowerColor(GrassData.FlowerType.decodeTileData(grassData));
-    }
-
-    public Color getSurfaceColorFor(Tile tile) {
-        return tile.getColor();
-    }
-
-    public Color getCaveColorFor(Tile tile) {
-        return CaveColors.getColorFor(tile);
-    }
+    Color getCaveColorFor(Tile tile);
 
     /**
-     * Color used for an unknown tile type
+     * Color used for an unknown tile type on the surface.
+     * @return Color for unknown tile type.
+     */
+    Color getSurfaceUnknownColor();
+
+    /**
+     *
      * @return
      */
-    public Color getSurfaceUnknownColor() {
-        return Tile.TILE_DIRT.getColor();
-    }
-
-    public Color getCaveUnknownColor() {
-        return CaveColors.getColorFor(Tile.TILE_CAVE);
-    }
+    Color getCaveUnknownColor();
 }

--- a/src/com/wurmonline/wurmapi/api/map/dump/Colorist.java
+++ b/src/com/wurmonline/wurmapi/api/map/dump/Colorist.java
@@ -2,6 +2,7 @@ package com.wurmonline.wurmapi.api.map.dump;
 
 import com.wurmonline.mesh.GrassData;
 import com.wurmonline.mesh.Tiles.Tile;
+import com.wurmonline.mesh.TreeData;
 
 import java.awt.*;
 
@@ -13,7 +14,7 @@ public interface Colorist {
 
     Color getFlowerColorFor(int meshEncodedTile);
 
-    Color getTreeColorFor(int meshEncodedTile);
+    Color getTreeColorFor(TreeData.TreeType treeType);
 
     Color getSurfaceColorFor(Tile tile);
 
@@ -26,8 +27,7 @@ public interface Colorist {
     Color getSurfaceUnknownColor();
 
     /**
-     *
-     * @return
+     * @return Color for unknown underground tile type.
      */
     Color getCaveUnknownColor();
 }

--- a/src/com/wurmonline/wurmapi/api/map/dump/Colorist.java
+++ b/src/com/wurmonline/wurmapi/api/map/dump/Colorist.java
@@ -1,0 +1,65 @@
+package com.wurmonline.wurmapi.api.map.dump;
+
+import com.wurmonline.mesh.GrassData;
+import com.wurmonline.mesh.Tiles;
+import com.wurmonline.mesh.Tiles.Tile;
+import com.wurmonline.wurmapi.internal.CaveColors;
+
+import java.awt.*;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Provides colour information for map dumps
+ */
+public class Colorist {
+    private static final Color PURPLE = Color.getHSBColor(0.7638888888888889f, 0.7f, 0.6f);
+
+    private static final Color YELLOW_GREEN = Color.getHSBColor(0.188888f, 1.0f, 0.9f);
+
+    private static final Map<GrassData.FlowerType, Color> FLOWER_COLOUR;
+    static {
+        Map<GrassData.FlowerType, Color> flowerColour = new HashMap<>();
+        flowerColour.put(GrassData.FlowerType.FLOWER_1, Color.YELLOW);
+        flowerColour.put(GrassData.FlowerType.FLOWER_2, Color.ORANGE);
+        flowerColour.put(GrassData.FlowerType.FLOWER_3, PURPLE);
+        flowerColour.put(GrassData.FlowerType.FLOWER_4, Color.WHITE);
+        flowerColour.put(GrassData.FlowerType.FLOWER_5, Color.BLUE);
+        flowerColour.put(GrassData.FlowerType.FLOWER_6, YELLOW_GREEN);
+        flowerColour.put(GrassData.FlowerType.FLOWER_7, Color.PINK);
+        flowerColour.put(GrassData.FlowerType.NONE, Tile.TILE_GRASS.getColor());
+        FLOWER_COLOUR = Collections.unmodifiableMap(flowerColour);
+    }
+
+    public Color getFlowerColor(GrassData.FlowerType flowerType) {
+        return FLOWER_COLOUR.containsKey(flowerType) ?
+                FLOWER_COLOUR.get(flowerType) :
+                FLOWER_COLOUR.get(GrassData.FlowerType.NONE);
+    }
+
+    public Color getFlowerColor(int meshEncodedTile) {
+        byte grassData = Tiles.decodeData(meshEncodedTile);
+        return getFlowerColor(GrassData.FlowerType.decodeTileData(grassData));
+    }
+
+    public Color getSurfaceColorFor(Tile tile) {
+        return tile.getColor();
+    }
+
+    public Color getCaveColorFor(Tile tile) {
+        return CaveColors.getColorFor(tile);
+    }
+
+    /**
+     * Color used for an unknown tile type
+     * @return
+     */
+    public Color getSurfaceUnknownColor() {
+        return Tile.TILE_DIRT.getColor();
+    }
+
+    public Color getCaveUnknownColor() {
+        return CaveColors.getColorFor(Tile.TILE_CAVE);
+    }
+}

--- a/src/com/wurmonline/wurmapi/api/map/dump/DefaultColorist.java
+++ b/src/com/wurmonline/wurmapi/api/map/dump/DefaultColorist.java
@@ -1,0 +1,118 @@
+package com.wurmonline.wurmapi.api.map.dump;
+
+import com.wurmonline.mesh.GrassData;
+import com.wurmonline.mesh.Tiles;
+import com.wurmonline.mesh.TreeData;
+
+import java.awt.*;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Provides default colours for a map dump.
+ */
+public class DefaultColorist implements Colorist {
+    private static final Color PURPLE = new Color(108, 46, 153);
+    private static final Color YELLOW_GREEN = new Color(200, 230, 0);
+
+    private static final Map<GrassData.FlowerType, Color> FLOWER_COLOR;
+    private static final Color FLOWER_COLOR_UNKNOWN = Tiles.Tile.TILE_GRASS.getColor();
+    static {
+        Map<GrassData.FlowerType, Color> flowerColour = new HashMap<>();
+        flowerColour.put(GrassData.FlowerType.FLOWER_1, Color.YELLOW);
+        flowerColour.put(GrassData.FlowerType.FLOWER_2, Color.ORANGE);
+        flowerColour.put(GrassData.FlowerType.FLOWER_3, PURPLE);
+        flowerColour.put(GrassData.FlowerType.FLOWER_4, Color.WHITE);
+        flowerColour.put(GrassData.FlowerType.FLOWER_5, Color.BLUE);
+        flowerColour.put(GrassData.FlowerType.FLOWER_6, YELLOW_GREEN);
+        flowerColour.put(GrassData.FlowerType.FLOWER_7, Color.PINK);
+        flowerColour.put(GrassData.FlowerType.NONE, FLOWER_COLOR_UNKNOWN);
+        FLOWER_COLOR = Collections.unmodifiableMap(flowerColour);
+    }
+
+    private static final Map<TreeData.TreeType, Color> TREE_COLOR;
+    private static final Color TREE_COLOR_UNKNOWN = Tiles.Tile.TILE_GRASS.getColor();
+    static {
+        // Some colours will be similar to the material but some will not, to aid in differentiating tree types.
+        Map<TreeData.TreeType, Color> treeColour = new HashMap<>();
+        treeColour.put(TreeData.TreeType.BIRCH, Color.WHITE);
+        treeColour.put(TreeData.TreeType.PINE, Color.YELLOW.brighter());
+        treeColour.put(TreeData.TreeType.OAK, Color.BLACK);
+        treeColour.put(TreeData.TreeType.CEDAR, Color.CYAN);
+        treeColour.put(TreeData.TreeType.WILLOW, Color.DARK_GRAY);
+        treeColour.put(TreeData.TreeType.MAPLE, PURPLE);
+        treeColour.put(TreeData.TreeType.APPLE, YELLOW_GREEN);
+        treeColour.put(TreeData.TreeType.LEMON, Color.YELLOW);
+        treeColour.put(TreeData.TreeType.OLIVE, new Color(80, 80, 0));
+        treeColour.put(TreeData.TreeType.CHERRY, Color.RED);
+        treeColour.put(TreeData.TreeType.CHESTNUT, Color.LIGHT_GRAY);
+        treeColour.put(TreeData.TreeType.WALNUT, Color.ORANGE);
+        treeColour.put(TreeData.TreeType.FIR, Color.GREEN.darker());
+        treeColour.put(TreeData.TreeType.LINDEN, Color.PINK);
+        TREE_COLOR = Collections.unmodifiableMap(treeColour);
+    }
+
+    private static final Map<Tiles.Tile, Color> CAVE_COLORS;
+    private static final Color CAVE_COLOR_UNKNOWN = Color.PINK;
+    static {
+        Map<Tiles.Tile, Color> caveColors = new HashMap<>();
+        caveColors.put(Tiles.Tile.TILE_CAVE_WALL, Color.DARK_GRAY);
+        caveColors.put(Tiles.Tile.TILE_CAVE_WALL_REINFORCED, Color.DARK_GRAY);
+        caveColors.put(Tiles.Tile.TILE_CAVE, Color.PINK);
+        caveColors.put(Tiles.Tile.TILE_CAVE_FLOOR_REINFORCED, Color.PINK);
+        caveColors.put(Tiles.Tile.TILE_CAVE_EXIT, Color.PINK);
+        caveColors.put(Tiles.Tile.TILE_CAVE_WALL_ORE_IRON, Color.RED.darker());
+        caveColors.put(Tiles.Tile.TILE_CAVE_WALL_LAVA, Color.RED);
+        caveColors.put(Tiles.Tile.TILE_CAVE_WALL_ORE_COPPER, Color.GREEN);
+        caveColors.put(Tiles.Tile.TILE_CAVE_WALL_ORE_TIN, Color.GRAY);
+        caveColors.put(Tiles.Tile.TILE_CAVE_WALL_ORE_GOLD, Color.YELLOW.darker());
+        caveColors.put(Tiles.Tile.TILE_CAVE_WALL_ORE_ADAMANTINE, Color.CYAN);
+        caveColors.put(Tiles.Tile.TILE_CAVE_WALL_ORE_GLIMMERSTEEL, Color.YELLOW.brighter());
+        caveColors.put(Tiles.Tile.TILE_CAVE_WALL_ORE_SILVER, Color.LIGHT_GRAY);
+        caveColors.put(Tiles.Tile.TILE_CAVE_WALL_ORE_LEAD, Color.PINK.darker().darker());
+        caveColors.put(Tiles.Tile.TILE_CAVE_WALL_ORE_ZINC, new Color(235, 235, 235));
+        caveColors.put(Tiles.Tile.TILE_CAVE_WALL_SLATE, Color.BLACK);
+        caveColors.put(Tiles.Tile.TILE_CAVE_WALL_MARBLE, Color.WHITE);
+        CAVE_COLORS = Collections.unmodifiableMap(caveColors);
+    }
+
+    private static final Color SURFACE_COLOR_UNKNOWN = Tiles.Tile.TILE_DIRT.getColor();
+
+    public Color getFlowerColorFor(GrassData.FlowerType flowerType) {
+        return FLOWER_COLOR.getOrDefault(flowerType, FLOWER_COLOR_UNKNOWN);
+    }
+
+    public Color getFlowerColorFor(int meshEncodedTile) {
+        byte grassData = Tiles.decodeData(meshEncodedTile);
+        return getFlowerColorFor(GrassData.FlowerType.decodeTileData(grassData));
+    }
+
+    public Color getTreeColorFor(int meshEncodedTile) {
+        byte treeData = Tiles.decodeData(meshEncodedTile);
+        return getTreeColorFor(TreeData.TreeType.fromTileData(treeData));
+    }
+
+    public Color getTreeColorFor(TreeData.TreeType treeType) {
+        return TREE_COLOR.getOrDefault(treeType, TREE_COLOR_UNKNOWN);
+    }
+
+    public Color getSurfaceColorFor(Tiles.Tile tile) {
+        return tile.getColor();
+    }
+
+    public Color getCaveColorFor(Tiles.Tile tile) {
+        return CAVE_COLORS.getOrDefault(tile, CAVE_COLOR_UNKNOWN);
+    }
+
+    public Color getSurfaceUnknownColor() {
+        return SURFACE_COLOR_UNKNOWN;
+    }
+
+    /**
+     * @return Color for unknown tile type.
+     */
+    public Color getCaveUnknownColor() {
+        return CAVE_COLOR_UNKNOWN;
+    }
+}

--- a/src/com/wurmonline/wurmapi/api/map/dump/DefaultColorist.java
+++ b/src/com/wurmonline/wurmapi/api/map/dump/DefaultColorist.java
@@ -79,39 +79,41 @@ public class DefaultColorist implements Colorist {
 
     private static final Color SURFACE_COLOR_UNKNOWN = Tiles.Tile.TILE_DIRT.getColor();
 
+    @Override
     public Color getFlowerColorFor(GrassData.FlowerType flowerType) {
         return FLOWER_COLOR.getOrDefault(flowerType, FLOWER_COLOR_UNKNOWN);
     }
 
+    @Override
     public Color getFlowerColorFor(int meshEncodedTile) {
         byte grassData = Tiles.decodeData(meshEncodedTile);
         return getFlowerColorFor(GrassData.FlowerType.decodeTileData(grassData));
     }
 
-    public Color getTreeColorFor(int meshEncodedTile) {
-        byte treeData = Tiles.decodeData(meshEncodedTile);
-        return getTreeColorFor(TreeData.TreeType.fromTileData(treeData));
-    }
-
+    @Override
     public Color getTreeColorFor(TreeData.TreeType treeType) {
         return TREE_COLOR.getOrDefault(treeType, TREE_COLOR_UNKNOWN);
     }
 
+    @Override
     public Color getSurfaceColorFor(Tiles.Tile tile) {
         return tile.getColor();
     }
 
+    @Override
     public Color getCaveColorFor(Tiles.Tile tile) {
         return CAVE_COLORS.getOrDefault(tile, CAVE_COLOR_UNKNOWN);
     }
 
+    /**
+     * @return Color for unknown surface tile type.
+     */
+    @Override
     public Color getSurfaceUnknownColor() {
         return SURFACE_COLOR_UNKNOWN;
     }
 
-    /**
-     * @return Color for unknown tile type.
-     */
+    @Override
     public Color getCaveUnknownColor() {
         return CAVE_COLOR_UNKNOWN;
     }

--- a/src/main/java/com/wurmonline/wurmapi/api/MapData.java
+++ b/src/main/java/com/wurmonline/wurmapi/api/MapData.java
@@ -8,6 +8,7 @@ import com.wurmonline.mesh.Tiles;
 import com.wurmonline.mesh.Tiles.Tile;
 import com.wurmonline.mesh.TreeData.TreeType;
 import com.wurmonline.wurmapi.api.map.dump.Colorist;
+import com.wurmonline.wurmapi.api.map.dump.DefaultColorist;
 
 import java.awt.Color;
 import java.awt.image.BufferedImage;
@@ -31,8 +32,7 @@ public final class MapData {
     private final MeshIO caveMesh;
     private final MeshIO resourcesMesh;
     private final MeshIO[] allMeshes;
-    private final Colorist colorist;
-    
+
     MapData(String root) throws IOException {
         this.surfaceMesh = MeshIO.open(root + "top_layer.map");
         this.rockMesh = MeshIO.open(root + "rock_layer.map");
@@ -40,18 +40,16 @@ public final class MapData {
         this.caveMesh = MeshIO.open(root + "map_cave.map");
         this.resourcesMesh = MeshIO.open(root + "resources.map");
         allMeshes = new MeshIO[] {surfaceMesh, rockMesh, flagsMesh, caveMesh, resourcesMesh};
-        this.colorist = new Colorist();
     }
-    
-    MapData(String root, int powerOfTwo, Colorist colorist) throws IOException {
+
+    MapData(String root, int powerOfTwo) throws IOException {
         this.surfaceMesh = createMap(root + "top_layer.map", powerOfTwo);
         this.rockMesh = createMap(root + "rock_layer.map", powerOfTwo);
         this.flagsMesh = createMap(root + "flags.map", powerOfTwo);
         this.caveMesh = createMap(root + "map_cave.map", powerOfTwo);
         this.resourcesMesh = createMap(root + "resources.map", powerOfTwo);
         allMeshes = new MeshIO[] {surfaceMesh, rockMesh, flagsMesh, caveMesh, resourcesMesh};
-        this.colorist = colorist;
-        
+
         int halfWidth = getWidth() / 2;
         int halfHeight = getHeight() / 2;
         
@@ -555,11 +553,11 @@ public final class MapData {
     }
 
     public BufferedImage createFlowerDump(boolean showWater) {
-        return createFlatDump(true, showWater, true, false);
+        return createFlatDump(true, showWater, true, false, new DefaultColorist());
     }
 
     public BufferedImage createTreeDump(boolean showWater) {
-        return createFlatDump(true, showWater, false, true);
+        return createFlatDump(true, showWater, false, true, new DefaultColorist());
     }
 
     /**
@@ -575,11 +573,11 @@ public final class MapData {
     }
 
     private BufferedImage createFlatDump(boolean isSurface, boolean showWater, Tile... allowedTiles) {
-        return createFlatDump(isSurface, showWater, false, false, allowedTiles);
+        return createFlatDump(isSurface, showWater, false, false, new DefaultColorist(), allowedTiles);
     }
 
     private BufferedImage createFlatDump(boolean isSurface, boolean showWater, boolean showFlowerTypes,
-                                         boolean showTreeTypes, Tile... allowedTiles) {
+                                         boolean showTreeTypes, Colorist colorist, Tile... allowedTiles) {
         final MeshIO terrainMesh;
         if (isSurface) {
             terrainMesh = surfaceMesh;
@@ -637,9 +635,9 @@ public final class MapData {
                 if (tile != null) {
                     if (isSurface) {
                         if (tile.isGrass() && showFlowerTypes) {
-                            color = colorist.getFlowerColor(encodedTile);
+                            color = colorist.getFlowerColorFor(encodedTile);
                         } else if (tile.isTree() && showTreeTypes) {
-                            color = colorist.getSurfaceColorFor(tile);
+                            color = colorist.getTreeColorFor(encodedTile);
                         } else {
                             color = colorist.getSurfaceColorFor(tile);
                         }

--- a/src/main/java/com/wurmonline/wurmapi/api/MapData.java
+++ b/src/main/java/com/wurmonline/wurmapi/api/MapData.java
@@ -637,7 +637,7 @@ public final class MapData {
                         if (tile.isGrass() && showFlowerTypes) {
                             color = colorist.getFlowerColorFor(encodedTile);
                         } else if (tile.isTree() && showTreeTypes) {
-                            color = colorist.getTreeColorFor(encodedTile);
+                            color = colorist.getTreeColorFor(tile.getTreeType(Tiles.decodeData(encodedTile)));
                         } else {
                             color = colorist.getSurfaceColorFor(tile);
                         }

--- a/src/main/java/com/wurmonline/wurmapi/api/MapData.java
+++ b/src/main/java/com/wurmonline/wurmapi/api/MapData.java
@@ -7,7 +7,8 @@ import com.wurmonline.mesh.MeshIO;
 import com.wurmonline.mesh.Tiles;
 import com.wurmonline.mesh.Tiles.Tile;
 import com.wurmonline.mesh.TreeData.TreeType;
-import com.wurmonline.wurmapi.internal.CaveColors;
+import com.wurmonline.wurmapi.api.map.dump.Colorist;
+
 import java.awt.Color;
 import java.awt.image.BufferedImage;
 import java.io.File;
@@ -19,13 +20,18 @@ import java.util.logging.Logger;
 public final class MapData {
     
     private static final float MAP_HEIGHT = 1000;
-    
+
+    public static final int DEFAULT_ROCK_RESOURCE_COUNT = 51;
+
+    public static final int DEFAULT_ORE_RESOURCE_COUNT = 1000;
+
     private final MeshIO surfaceMesh;
     private final MeshIO rockMesh;
     private final MeshIO flagsMesh;
     private final MeshIO caveMesh;
     private final MeshIO resourcesMesh;
     private final MeshIO[] allMeshes;
+    private final Colorist colorist;
     
     MapData(String root) throws IOException {
         this.surfaceMesh = MeshIO.open(root + "top_layer.map");
@@ -34,15 +40,17 @@ public final class MapData {
         this.caveMesh = MeshIO.open(root + "map_cave.map");
         this.resourcesMesh = MeshIO.open(root + "resources.map");
         allMeshes = new MeshIO[] {surfaceMesh, rockMesh, flagsMesh, caveMesh, resourcesMesh};
+        this.colorist = new Colorist();
     }
     
-    MapData(String root, int powerOfTwo) throws IOException {
+    MapData(String root, int powerOfTwo, Colorist colorist) throws IOException {
         this.surfaceMesh = createMap(root + "top_layer.map", powerOfTwo);
         this.rockMesh = createMap(root + "rock_layer.map", powerOfTwo);
         this.flagsMesh = createMap(root + "flags.map", powerOfTwo);
         this.caveMesh = createMap(root + "map_cave.map", powerOfTwo);
         this.resourcesMesh = createMap(root + "resources.map", powerOfTwo);
         allMeshes = new MeshIO[] {surfaceMesh, rockMesh, flagsMesh, caveMesh, resourcesMesh};
+        this.colorist = colorist;
         
         int halfWidth = getWidth() / 2;
         int halfHeight = getHeight() / 2;
@@ -205,7 +213,8 @@ public final class MapData {
     /**
      * Places tree in specified position in game world.<br><br>
      * 
-     * Placing tree should happen after calling {@link #setSurfaceTile(int, int, short, com.wurmonline.mesh.Tiles.Tile) setSurfaceTile}, as it is using data from a tile (height and grass type) to generate the final tree data.<br>
+     * Placing tree should happen after calling {@link #setSurfaceTile(int, int, Tile, short) setSurfaceTile},
+     * as it is using data from a tile (height and grass type) to generate the final tree data.<br>
      * This method will NOT prevent doing illogical things like placing trees under water.<br><br>
      * 
      * Under the hood, 1 byte of tree special data is composed of these values:<br>
@@ -249,7 +258,8 @@ public final class MapData {
     /**
      * Places bush in specified position in game world.<br><br>
      * 
-     * Placing bush should happen after calling {@link #setSurfaceTile(int, int, short, int) setSurfaceTile}, as it is using data from a tile (height and grass type) to generate the final bush data.<br>
+     * Placing bush should happen after calling {@link #setSurfaceTile(int, int, Tile, short) setSurfaceTile}, as it is
+     * using data from a tile (height and grass type) to generate the final bush data.<br>
      * This method will NOT prevent doing illogical things like placing grass under water.<br><br>
      * 
      * Under the hood, 1 byte of bush special data is composed in the same way as tree data: {@link #setTree(int, int, com.wurmonline.mesh.TreeData.TreeType, com.wurmonline.mesh.FoliageAge, com.wurmonline.mesh.GrassData.GrowthTreeStage) setTree}.
@@ -364,7 +374,7 @@ public final class MapData {
     public Tile getCaveTile(int x, int y) {
         return Tiles.getTile(Tiles.decodeType(caveMesh.getTile(x, y)));
     }
-    
+
     /**
      * Sets tile data inside cave.<br>
      * Only solid cave walls are allowed - exception will be thrown on attempt to set non-cave tile type or cave type which is not a wall.<br>
@@ -376,10 +386,10 @@ public final class MapData {
      */
     public void setCaveTile(int x, int y, Tile tileType) {
         if (tileType == Tile.TILE_CAVE_WALL) {
-            setCaveTile(x, y, tileType, (short) 51);
+            setCaveTile(x, y, tileType, (short) DEFAULT_ROCK_RESOURCE_COUNT);
         }
         else {
-            setCaveTile(x, y, tileType, (short) 1000);
+            setCaveTile(x, y, tileType, (short) DEFAULT_ORE_RESOURCE_COUNT);
         }
     }
     
@@ -408,7 +418,7 @@ public final class MapData {
     }
     
     private void setCaveTile(int x, int y, Tile tileType, short height, byte data) {
-        caveMesh.setTile(x, y, Tiles.encode(height, (byte) tileType.getId(), data));
+        caveMesh.setTile(x, y, Tiles.encode(height, tileType.getId(), data));
     }
     
     /**
@@ -543,7 +553,15 @@ public final class MapData {
     public BufferedImage createTerrainDump(boolean showWater) {
         return createFlatDump(true, showWater);
     }
-    
+
+    public BufferedImage createFlowerDump(boolean showWater) {
+        return createFlatDump(true, showWater, true, false);
+    }
+
+    public BufferedImage createTreeDump(boolean showWater) {
+        return createFlatDump(true, showWater, false, true);
+    }
+
     /**
      * Creates flat map dump, showing all cave terrain types in different colors.<br>
      * You don't need to save map first to create updated map dump - it is using data from memory.
@@ -555,8 +573,13 @@ public final class MapData {
     public BufferedImage createCaveDump(boolean showWater, Tile... tiles) {
         return createFlatDump(false, showWater, tiles);
     }
-    
+
     private BufferedImage createFlatDump(boolean isSurface, boolean showWater, Tile... allowedTiles) {
+        return createFlatDump(isSurface, showWater, false, false, allowedTiles);
+    }
+
+    private BufferedImage createFlatDump(boolean isSurface, boolean showWater, boolean showFlowerTypes,
+                                         boolean showTreeTypes, Tile... allowedTiles) {
         final MeshIO terrainMesh;
         if (isSurface) {
             terrainMesh = surfaceMesh;
@@ -595,7 +618,8 @@ public final class MapData {
         for (int x = 0; x < lWidth; x++) {
             for (int y = lWidth - 1; y >= 0; y--) {
                 final short height = Tiles.decodeHeight(heightMesh.getTile(x + xo, y + yo));
-                final byte tex = Tiles.decodeType(terrainMesh.getTile(x + xo, y + yo));
+                final int encodedTile = terrainMesh.getTile(x + xo, y + yo);
+                final byte tex = Tiles.decodeType(encodedTile);
                 final Tile tile = Tiles.getTile(tex);
                 boolean visible = true;
                 
@@ -612,21 +636,27 @@ public final class MapData {
                 final Color color;
                 if (tile != null) {
                     if (isSurface) {
-                        color = tile.getColor();
+                        if (tile.isGrass() && showFlowerTypes) {
+                            color = colorist.getFlowerColor(encodedTile);
+                        } else if (tile.isTree() && showTreeTypes) {
+                            color = colorist.getSurfaceColorFor(tile);
+                        } else {
+                            color = colorist.getSurfaceColorFor(tile);
+                        }
                     }
                     else if (visible) {
-                        color = CaveColors.getColorFor(tile);
+                        color = colorist.getCaveColorFor(tile);
                     }
                     else {
-                        color = CaveColors.getColorFor(Tile.TILE_CAVE_WALL);
+                        color = colorist.getCaveColorFor(Tile.TILE_CAVE_WALL);
                     }
                 }
                 else {
                     if (isSurface) {
-                        color = Tile.TILE_DIRT.getColor();
+                        color = colorist.getSurfaceUnknownColor();
                     }
                     else {
-                        color = CaveColors.getColorFor(Tile.TILE_CAVE);
+                        color = colorist.getCaveUnknownColor();
                     }
                 }
                 int r = color.getRed();
@@ -647,7 +677,7 @@ public final class MapData {
         bi2.getRaster().setPixels(0, 0, lWidth, lWidth, data);
         return bi2;
     }
-    
+
     /**
      * Creates flat map dump, showing all terrain types in different colors and with contour lines.<br>
      * You don't need to save map first to create updated map dump - it is using data from memory.

--- a/src/main/java/com/wurmonline/wurmapi/api/WurmAPI.java
+++ b/src/main/java/com/wurmonline/wurmapi/api/WurmAPI.java
@@ -1,5 +1,7 @@
 package com.wurmonline.wurmapi.api;
 
+import com.wurmonline.wurmapi.api.map.dump.Colorist;
+
 import java.io.File;
 import java.io.IOException;
 
@@ -46,7 +48,7 @@ public class WurmAPI {
         File file = new File(rootDir);
         file.mkdirs();
         
-        this.mapData = new MapData(rootDir, powerOfTwo);
+        this.mapData = new MapData(rootDir, powerOfTwo, new Colorist());
     }
     
     public MapData getMapData() {

--- a/src/main/java/com/wurmonline/wurmapi/api/WurmAPI.java
+++ b/src/main/java/com/wurmonline/wurmapi/api/WurmAPI.java
@@ -48,7 +48,7 @@ public class WurmAPI {
         File file = new File(rootDir);
         file.mkdirs();
         
-        this.mapData = new MapData(rootDir, powerOfTwo, new Colorist());
+        this.mapData = new MapData(rootDir, powerOfTwo);
     }
     
     public MapData getMapData() {

--- a/src/main/java/com/wurmonline/wurmapi/internal/CaveColors.java
+++ b/src/main/java/com/wurmonline/wurmapi/internal/CaveColors.java
@@ -32,7 +32,7 @@ public class CaveColors {
     private static void addMapping(Tile tile, Color color) {
         mappings.put(tile, color);
     }
-    
+
     public static Color getColorFor(Tile tile) {
         return mappings.getOrDefault(tile, Color.PINK);
     }

--- a/src/main/java/com/wurmonline/wurmapi/internal/CaveColors.java
+++ b/src/main/java/com/wurmonline/wurmapi/internal/CaveColors.java
@@ -5,6 +5,7 @@ import java.awt.Color;
 import java.util.HashMap;
 import java.util.Map;
 
+@Deprecated
 public class CaveColors {
     
     private static final Map<Tile, Color> mappings = new HashMap<>();


### PR DESCRIPTION
Rebased version of PR #3 . Pulled colors off into dedicated Colorist interface, with DefaultColorist class as a default color provider. Callers may specify their own colors by implementing Colorist and providing it as an argument to createFlatDump, eg:
```Java
createFlatDump(true, showWater, true, false, new MyCustomColorist())
```